### PR TITLE
YTI-448 CSV parse fix

### DIFF
--- a/src/main/java/fi/vm/yti/codelist/intake/parser/impl/CodeParserImpl.java
+++ b/src/main/java/fi/vm/yti/codelist/intake/parser/impl/CodeParserImpl.java
@@ -60,7 +60,7 @@ public class CodeParserImpl extends AbstractBaseParser implements CodeParser {
         final Set<String> codeValues = new HashSet<>();
         try (final InputStreamReader inputStreamReader = new InputStreamReader(new BOMInputStream(inputStream), StandardCharsets.UTF_8);
              final BufferedReader in = new BufferedReader(inputStreamReader);
-             final CSVParser csvParser = new CSVParser(in, CSVFormat.newFormat(',').withQuote('"').withQuoteMode(QuoteMode.MINIMAL).withHeader())) {
+             final CSVParser csvParser = new CSVParser(in, CSVFormat.newFormat(',').withQuote('"').withAllowDuplicateHeaderNames(false).withQuoteMode(QuoteMode.MINIMAL).withHeader())) {
             final Map<String, Integer> headerMap = csvParser.getHeaderMap();
             final Map<String, Integer> prefLabelHeaders = parseHeadersWithPrefix(headerMap, CONTENT_HEADER_PREFLABEL_PREFIX);
             final Map<String, Integer> definitionHeaders = parseHeadersWithPrefix(headerMap, CONTENT_HEADER_DEFINITION_PREFIX);


### PR DESCRIPTION
Add withAllowDuplicateHeaderNames(false) because it's set to true in new version of csv parser library